### PR TITLE
Replace matches with find, improves performance and fixes bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 **/.project
 **/.settings/*
 **/target
+
+.idea/
+*.iml

--- a/streamflyer-core/src/main/java/com/github/rwitzel/streamflyer/xml/XmlVersionModifier.java
+++ b/streamflyer-core/src/main/java/com/github/rwitzel/streamflyer/xml/XmlVersionModifier.java
@@ -166,16 +166,16 @@ public class XmlVersionModifier implements Modifier {
             // (Should we do aware of BOMs here? No. I consider it the
             // responsibility of the caller to provide characters without BOM.)
 
-            Matcher matcher = Pattern.compile("<\\?xml[^>]*version\\s*=\\s*['\"]((1.0)|(1.1))['\"].*").matcher(
+            Matcher matcher = Pattern.compile("^<\\?xml[^>]*version\\s*=\\s*['\"](1.[01])['\"]").matcher(
                     characterBuffer);
-            if (matcher.matches()) {
+            if (matcher.find()) {
 
                 // replace version in prolog
                 characterBuffer.replace(matcher.start(1), matcher.end(1), xmlVersion);
             } else {
                 // is there a prolog that is too long?
-                Matcher matcher2 = Pattern.compile("<\\?xml.*").matcher(characterBuffer);
-                if (matcher2.matches()) {
+                Matcher matcher2 = Pattern.compile("^<\\?xml").matcher(characterBuffer);
+                if (matcher2.find()) {
                     // this is not normal at all -> throw exception
                     throw new XmlPrologRidiculouslyLongException(characterBuffer.toString());
                 }

--- a/streamflyer-core/src/test/java/com/github/rwitzel/streamflyer/xml/XmlVersionModifierTest.java
+++ b/streamflyer-core/src/test/java/com/github/rwitzel/streamflyer/xml/XmlVersionModifierTest.java
@@ -59,6 +59,10 @@ public class XmlVersionModifierTest {
 
         // version in prolog has double quotes
         assertXmlVersionInProlog("<?xml version=\"1.1\">", "1.0", "<?xml version=\"1.0\">");
+        
+        // string contains trailing newlines
+        assertXmlVersionInProlog("<?xml version=\"1.0\">\n<testResults>\n<tag>value</tag>\n</testResults>", "1.1", "<?xml version=\"1.1\">\n<testResults>\n<tag>value</tag>\n</testResults>");
+        
     }
 
     @Test

--- a/streamflyer-experimental/src/main/java/com/github/rwitzel/streamflyer/experimental/xml/XmlVersionModifier.java
+++ b/streamflyer-experimental/src/main/java/com/github/rwitzel/streamflyer/experimental/xml/XmlVersionModifier.java
@@ -91,17 +91,17 @@ public class XmlVersionModifier implements Modifier {
                 // responsibility of the caller to provide characters without
                 // BOM.)
 
-                Matcher matcher = Pattern.compile("<\\?xml[^>]*version\\s*=\\s*['\"]((1.0)|(1.1))['\"].*").matcher(
+                Matcher matcher = Pattern.compile("^<\\?xml[^>]*version\\s*=\\s*['\"](1.[01])['\"]").matcher(
                         characterBuffer);
-                if (matcher.matches()) {
+                if (matcher.find()) {
 
                     // replace version in prolog
                     characterBuffer.replace(matcher.start(1), matcher.end(1), XmlVersionModifier.this.xmlVersion);
                 } else {
 
                     // is there a prolog that is too long?
-                    Matcher matcher2 = Pattern.compile("<\\?xml.*").matcher(characterBuffer);
-                    if (matcher2.matches()) {
+                    Matcher matcher2 = Pattern.compile("^<\\?xml").matcher(characterBuffer);
+                    if (matcher2.find()) {
                         // this is not normal at all -> throw exception
                         throw new XmlPrologRidiculouslyLongException(characterBuffer.toString());
                     }


### PR DESCRIPTION
Currently the pattern doesn't match since `.*` without the `DOTALL` flag doesn't match newlines, so that `.matches()` returns false if there are newlines following the string.

I also converted `match` to `find` since we don't need to match the entire string (but just the start of it). This has a great performance benefit (up to 2x in my benchmarks)